### PR TITLE
Bubble chart

### DIFF
--- a/frontend-friends/src/components/averageTimeNumCasesChart/averageTimeNumCasesChart.js
+++ b/frontend-friends/src/components/averageTimeNumCasesChart/averageTimeNumCasesChart.js
@@ -96,7 +96,7 @@ export default function TimePerCategory () {
           data: [{
             x:(numOfCases[i]),
             y:(caseAverageTime[i]),
-            r:(Math.round((numOfCases[i]+caseAverageTime[i])/2.5))
+            r:(Math.round(Math.sqrt(numOfCases[i]*caseAverageTime[i])))
           }],
           backgroundColor: tempColorArray[i],
         }

--- a/frontend-friends/src/components/averageTimeNumCasesChart/averageTimeNumCasesChart.js
+++ b/frontend-friends/src/components/averageTimeNumCasesChart/averageTimeNumCasesChart.js
@@ -1,0 +1,155 @@
+import { getData } from '../../utils/request'
+import { useState, useEffect } from 'react'
+import IntervalDropdown from '../intervalDropdown/intervalDropdown'
+import BubbleChart from '../bubbleChart/bubbleChart'
+
+export default function TimePerCategory () {
+  const [categories, setCategories] = useState([])
+  const [interval, setInterval] = useState(100)
+  const [caseAverageTime, setCaseAverageTime] = useState([])
+  const [numOfCases, setNumOfCases] = useState([])
+  const [categoryIDArray, setCategoryIDArray] = useState([])
+  const [xMax, setXMax] = useState(0)
+  const [xLabels, setXLabels] = useState([])
+
+  const colors = ['#579CFB', '#20E2BA', '#FD5E80', '#F8D347', '#BC6C25', '#00C864', '#A259FF', '#9694FF']
+
+  const [datasets, setDatasets] = useState([])
+
+  async function getCategories () {
+    const response = await getData('/case/categories')
+    const rawData = await response.json()
+    const categoryArray = []
+
+    for (const category of rawData) {
+      categoryArray.push(category.name)
+    }
+    setCategories(categoryArray)
+  }
+
+  async function getTime () {
+    const today = new Date()
+    const year = today.getFullYear()
+    const month = today.getMonth() + 1
+    const day = today.getDate()
+    let response = ''
+
+    if (interval === 100) {
+      response = await getData('/stats/category?start-time=0001-01-01T00:00:00%2B00:00&end-time=9999-12-31T23:59:59%2B00:00')
+    } else if (interval === 7 || interval === 14) {
+      let monthUpdated = month
+      let dayUpdated = day - interval
+      if (day - interval <= 0) { // If the week spans multiple months
+        monthUpdated = month - 1
+        const diff = Math.abs(day - interval)
+        const newDate = new Date(year, monthUpdated, 0)
+        dayUpdated = newDate.getDate() - diff
+      }
+      response = await getData(('/stats/category?start-time=' + (year + '-' + ('0' + (monthUpdated)).slice(-2) + '-' + ('0' + dayUpdated).slice(-2)) + 'T00:00:00&end-time=' + (year + '-' + ('0' + (month)).slice(-2) + '-' + ('0' + day).slice(-2)) + 'T23:59:59'))
+    } else if (interval === 4) {
+      let dayUpdated = day
+      if (month - 1 === 2 && day >= 29) {
+        dayUpdated = 28
+      }
+      response = await getData(('/stats/category?start-time=' + (year + '-' + ('0' + (month - 1)).slice(-2) + '-' + dayUpdated) + 'T00:00:00&end-time=' + (year + '-' + ('0' + (month)).slice(-2) + '-' + ('0' + day).slice(-2)) + 'T23:59:59'))
+    } else {
+      response = await getData(('/stats/category?start-time=' + ((year - 1) + '-' + ('0' + (month - 1)).slice(-2) + '-' + day) + 'T00:00:00&end-time=' + (year + '-' + ('0' + (month)).slice(-2) + '-' + ('0' + day).slice(-2)) + 'T23:59:59'))
+    }
+    const rawData = await response.json()
+    const tempArray = []
+    const tempIDArray = []
+    const tempNumArray = []
+    let maxCount = 0
+    for (const data of rawData) {
+      if(data.count > maxCount){
+        maxCount = data.count
+      }
+      setXMax(maxCount)
+
+      tempIDArray.push(data.category_id)
+      const count = data.count
+      const totalTime = (data.customer_time + data.additional_time)
+      let averageTime = Math.round(totalTime / count)
+      if (count === 0) {
+        averageTime = 0
+      }
+      tempArray.push(averageTime)
+      tempNumArray.push(count)
+    }
+    setCategoryIDArray(tempIDArray)
+    setCaseAverageTime(tempArray)
+    setNumOfCases(tempNumArray)
+  }
+
+  function createDatasets () {
+    const tempColorArray = []
+    for (const id of categoryIDArray) {
+      tempColorArray.push(colors[id % colors.length])
+    }
+
+    const dataArray = []
+    for (let i = 0; i < caseAverageTime.length; i++) {
+      dataArray.push(
+        {
+          type:'bubble',
+          label: categories[i],
+          data: [{
+            x:(numOfCases[i]),
+            y:(caseAverageTime[i]),
+            r:(Math.round((numOfCases[i]+caseAverageTime[i])/2.5))
+          }],
+          backgroundColor: tempColorArray[i],
+        }
+      )
+    }
+    setDatasets(dataArray)
+  }
+  useEffect(() => {
+    getCategories()
+      .then(() => getTime())
+      .catch(console.error)
+  }, [interval])
+
+  useEffect(() => {
+    if (caseAverageTime.length > 0 && categoryIDArray.length > 0) {
+      createDatasets()
+
+      const tempLabels = []
+      for (let i = 0; i <= xMax; i++) {
+        tempLabels.push(i)
+      }
+      setXLabels(tempLabels)
+    }
+  }, [caseAverageTime, categoryIDArray, xMax])
+
+  const handleChange = (event) => {
+    switch (event.target.value) {
+      case '2Week':
+        setInterval(14)
+        break
+      case '4Week':
+        setInterval(4)
+        break
+      case 'year':
+        setInterval(1)
+        break
+      case 'week':
+        setInterval(7)
+        break
+      default:
+        setInterval(100)
+        break
+    }
+  }
+
+  return (
+    <div>
+      <IntervalDropdown onChange={handleChange} options={{ alltime: 'Totalt', week: '1 vecka', '2Week': '2 veckor', '4Week': '4 veckor', year: '1 år' }} />
+      <BubbleChart
+        titletext='Antal ärenden och genomsnittlig tid per kategori'
+        datasets={datasets}
+        labels={xLabels}
+      />
+    </div>
+  )
+}

--- a/frontend-friends/src/components/averageTimeNumCasesChart/averageTimeNumCasesChart.js
+++ b/frontend-friends/src/components/averageTimeNumCasesChart/averageTimeNumCasesChart.js
@@ -61,7 +61,7 @@ export default function TimePerCategory () {
     const tempNumArray = []
     let maxCount = 0
     for (const data of rawData) {
-      if(data.count > maxCount){
+      if (data.count > maxCount) {
         maxCount = data.count
       }
       setXMax(maxCount)
@@ -91,14 +91,14 @@ export default function TimePerCategory () {
     for (let i = 0; i < caseAverageTime.length; i++) {
       dataArray.push(
         {
-          type:'bubble',
+          type: 'bubble',
           label: categories[i],
           data: [{
-            x:(numOfCases[i]),
-            y:(caseAverageTime[i]),
-            r:(Math.round(Math.sqrt(numOfCases[i]*caseAverageTime[i])))
+            x: (numOfCases[i]),
+            y: (caseAverageTime[i]),
+            r: (Math.round(Math.sqrt(numOfCases[i] * caseAverageTime[i])))
           }],
-          backgroundColor: tempColorArray[i],
+          backgroundColor: tempColorArray[i]
         }
       )
     }

--- a/frontend-friends/src/components/bubbleChart/bubbleChart.js
+++ b/frontend-friends/src/components/bubbleChart/bubbleChart.js
@@ -1,0 +1,94 @@
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+  BubbleController
+} from 'chart.js'
+import { Bubble } from 'react-chartjs-2'
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BubbleController,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+)
+
+/**
+ * Bar chart displaying the given data
+ * @param {*} props are the properties it contains
+ * @returns a bar chart component
+ */
+export default function bubbleChart (props) {
+  const data = {
+    labels: props.labels,
+    datasets: props.datasets
+  }
+  const options = ({
+    responsive: true,
+    plugins: {
+      legend: {
+        display: false,
+        position: 'right',
+      },
+      title: {
+        display: true,
+        position: 'top',
+        text: props.titletext,
+        padding: {
+          top: 10,
+          bottom: 10
+        },
+        font: {
+          size: 15,
+          family: ['Montserrat', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'sans-serif']
+        }
+      },
+      tooltip: {
+        callbacks: {
+          label: function (context) {
+            const label = context.dataset.label || '';
+            const xValue = context.parsed.x || '';
+            const yValue = context.parsed.y || '';
+            return label + ': (' + xValue + ', ' + yValue + ')';
+          },
+          // Hide the r value (radius)
+          labelPoint: function () {
+            return '';
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        title: {
+          display: true,
+          text: 'Antal ärenden'
+        },
+      },
+      y: {
+        title: {
+          display: true,
+          text: 'Genomsnittlig tid'
+        },
+        stacked: true,
+        ticks: {
+          beginAtZero: true,
+          stepSize: 1
+        }
+      }
+    }
+  })
+
+  return (
+    <div className='bar-button-wrapper'>
+      <Bubble data={data} options={options} />
+    </div>
+  )
+}

--- a/frontend-friends/src/components/bubbleChart/bubbleChart.js
+++ b/frontend-friends/src/components/bubbleChart/bubbleChart.js
@@ -35,7 +35,7 @@ export default function bubbleChart (props) {
     plugins: {
       legend: {
         display: false,
-        position: 'right',
+        position: 'right'
       },
       title: {
         display: true,
@@ -53,24 +53,24 @@ export default function bubbleChart (props) {
       tooltip: {
         callbacks: {
           label: function (context) {
-            const label = context.dataset.label || '';
-            const xValue = context.parsed.x || '';
-            const yValue = context.parsed.y || '';
-            return label + ': (' + xValue + ', ' + yValue + ')';
+            const label = context.dataset.label || ''
+            const xValue = context.parsed.x || ''
+            const yValue = context.parsed.y || ''
+            return label + ': (' + xValue + ', ' + yValue + ')'
           },
           // Hide the r value (radius)
           labelPoint: function () {
-            return '';
-          },
-        },
-      },
+            return ''
+          }
+        }
+      }
     },
     scales: {
       x: {
         title: {
           display: true,
           text: 'Antal ärenden'
-        },
+        }
       },
       y: {
         title: {

--- a/frontend-friends/src/components/dayTotalCasesLine/DayTotalCasesLine.js
+++ b/frontend-friends/src/components/dayTotalCasesLine/DayTotalCasesLine.js
@@ -60,7 +60,7 @@ export default function DayTotalCasesLine () {
   return (
     <div>
       <Datepicker onChange={(e) => setInputDate(e.target.value)} />
-      <LineChart datasets={datasets} labels={labels} />
+      <LineChart datasets={datasets} labels={labels} titletext='Totalt antal ärenden' />
     </div>
   )
 }

--- a/frontend-friends/src/components/lineChart/LineChart.js
+++ b/frontend-friends/src/components/lineChart/LineChart.js
@@ -51,7 +51,7 @@ export default function lineChart (props) {
           bottom: 10
         },
         font: {
-          size: 24,
+          size: 15,
           family: ['Montserrat', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'sans-serif']
         }
       },

--- a/frontend-friends/src/components/list/List.js
+++ b/frontend-friends/src/components/list/List.js
@@ -107,7 +107,7 @@ export default function List (props) {
               <td>{currCase.customer_time} min</td>
               <td>{currCase.additional_time} min</td>
               <td><div>{parseDate(currCase.created_at)}</div></td>
-              <td className='edit-field'>Redigera</td>
+              <td className='edit-field'>{props.hasPopup ? 'Redigera' : ''}</td>
               <td className='notes-icon'>
                 <div className='notes-icon-container'>
                   {/[a-z0-9$&+,:;=?@#|'<>.^*()%!-åäö]/i.test(currCase.notes) ? <NotesIcon /> : <></>}

--- a/frontend-friends/src/components/list/List.js
+++ b/frontend-friends/src/components/list/List.js
@@ -102,7 +102,7 @@ export default function List (props) {
         <tbody>
           {props.content.map((currCase, index) =>
             <tr onClick={() => togglePopup(currCase, index)} key={currCase.id}>
-              <td>#{currCase.case_id}</td>
+              <td>{currCase.case_id !== null ? '#' : ''}{currCase.case_id}</td>
               <td>{(currCase.category_name !== null ? currCase.category_name : 'Kategori saknas')}</td>
               <td>{currCase.customer_time} min</td>
               <td>{currCase.additional_time} min</td>

--- a/frontend-friends/src/components/list/List.js
+++ b/frontend-friends/src/components/list/List.js
@@ -103,7 +103,7 @@ export default function List (props) {
           {props.content.map((currCase, index) =>
             <tr onClick={() => togglePopup(currCase, index)} key={currCase.id}>
               <td>#{currCase.case_id}</td>
-              <td>{currCase.category_name}</td>
+              <td>{(currCase.category_name !== null ? currCase.category_name : 'Kategori saknas')}</td>
               <td>{currCase.customer_time} min</td>
               <td>{currCase.additional_time} min</td>
               <td><div>{parseDate(currCase.created_at)}</div></td>

--- a/frontend-friends/src/routes/caselist/CaseList.scss
+++ b/frontend-friends/src/routes/caselist/CaseList.scss
@@ -43,7 +43,7 @@
         align-items: center;
         user-select: none;
         display: flex;
-        justify-content: end;
+        justify-content: flex-end;
         margin-left: margins.$margin-md;
         margin-right: margins.$margin-md;
         margin-bottom: margins.$margin-md;

--- a/frontend-friends/src/routes/statistics/Statistics.js
+++ b/frontend-friends/src/routes/statistics/Statistics.js
@@ -4,6 +4,7 @@ import DayTotalCasesLine from '../../components/dayTotalCasesLine/DayTotalCasesL
 import NumOfCasesWeekBar from '../../components/customBarCharts/numOfCasesWeekBar'
 import NumOfCasesHourBar from '../../components/customBarCharts/numOfCasesHourBar'
 import TimePerCategory from '../../components/customBarCharts/timePerCategoryBar'
+import AverageTimeNumCasesChart from '../../components/averageTimeNumCasesChart/averageTimeNumCasesChart'
 /**
  * Component for displaying the statistics page.
  * @returns Statistics component
@@ -25,6 +26,9 @@ export default function Statistics () {
           </div>
           <div className='barchart-container'>
             <TimePerCategory />
+          </div>
+          <div className='barchart-container'>
+            <AverageTimeNumCasesChart />
           </div>
         </div>
       </PageWrapper>


### PR DESCRIPTION
Skapat ett nytt diagram på statistiksidan i form av ett bubbeldiagram som visar sambandet mellan genomsnittlig tid och antal ärenden per kategori. Högre genomsnittlig tid + fler ärenden = Större bubbla, vilket indikerar vart personal kan behöva lägga sina resurser.

Tips på test:
- Lägg till nya ärenden till olika kategorier och se så att kategorins bubbla ändras proportionerligt
- Ändra tidsintervall och se så att bubblorna ändras när de borde
- Lägg till en ny kategori och lägg in ett antal ärenden i den för att se så att en ny bubbla skapas
- Ta bort en kategori och se så att bubblan försvinner
- Ändra ett ärendes tidsåtgång i ärendelistan och se så att bubblan ändras

Edit: Är medveten om att sonarcloud failar men det beror på att den här komponenten delar en del funktioner med andra charts.